### PR TITLE
Delete attached volumes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,23 @@
 
 
 [[projects]]
-  digest = "1:30a2939b8cb90a4a42d62a0a8bdfdc9df5016608e595966ecdaed0900d3e49cb"
+  digest = "1:218ae0d3f01ab221e2a62493a88e72189fb4941b22f60984277c22f664d34c46"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "050b16d2314d5fc3d4c9a51e4cd5c7468e77f162"
   version = "v0.17.0"
 
 [[projects]]
-  digest = "1:f27716eda1a4f5a3a0bba7bd9b35b1f286a5c139c1b27e1d06185006e3c975be"
+  digest = "1:41bb9b595ed32431ad3076c2d8c25c3438b44880274c0d05505c70dd28f6028c"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = ["arm/resources/resources"]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "7692b0cef22674113fcf71cc17ac3ccc1a7fef48"
   version = "v11.2.2-beta"
 
 [[projects]]
-  digest = "1:4fb9eaa02a4907b14536906f970f725eca2397b29498911b6e655bb4d428a1e0"
+  digest = "1:7864932ecf50e0d092d50485b172b39923faf7608eccb24674afc4f9e715fb34"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -28,12 +28,12 @@
     "autorest/to",
     "autorest/validation",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "40e67ab508b948cd6ab4b4108ea42f3793ca19e3"
   version = "v9.5.2"
 
 [[projects]]
-  digest = "1:9563d099d677a0c1f321508b20c52544d8fbb241904d205783227301ccfc207c"
+  digest = "1:2087e306d0bee1a64ff9a4aa755cc0729db58e637bc118cb7f19f82e829ee979"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -82,51 +82,52 @@
     "service/s3/s3manager",
     "service/sts",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "04abd557eeaab3cfdded45467eea00fc03db9cb9"
   version = "v1.15.26"
 
 [[projects]]
-  digest = "1:3e93e899f8457138a891b3ccedcacf8fe9074865c848f7028e1892bdae280676"
+  digest = "1:217f778e19b8d206112c21d21a7cc72ca3cb493b67631680a2324bc50335d432"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
   version = "v3.1.0"
 
 [[projects]]
-  digest = "1:d7d69c103aba5ea229451115b28ca06d061e3861b2f44bcd0100cbc65659c4d9"
+  digest = "1:4bb94bb2d837b5c7489d9e5e1fcffbc81fa1cb43024cbb4fe827787378f01e3b"
   name = "github.com/fatih/color"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:a00483fe4106b86fb1187a92b5cf6915c85f294ed4c129ccbe7cb1f1a06abd46"
+  digest = "1:50772cf1f376b08cb57b4e8e9225775d9f9f4aad8487313afcb66846ceaa5d4c"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
+  digest = "1:9b0e71863f18fc5de645a263184c8a6409ae731e847b35b25da4be818f1975fa"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
-  digest = "1:1269c4a4dc19bb42dfac9e8e13982b745640b68b949566a8082ef8a6f641b7e9"
+  digest = "1:c6f3d621c9d58bf5ee80e18a878c5de252f8ba4ee160a7e4c2e90d15ee163e26"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
     "internal",
     "openstack",
     "openstack/blockstorage/v3/volumes",
+    "openstack/compute/v2/extensions/volumeattach",
     "openstack/compute/v2/flavors",
     "openstack/compute/v2/images",
     "openstack/compute/v2/servers",
@@ -135,69 +136,71 @@
     "openstack/identity/v3/tokens",
     "openstack/imageservice/v2/imagedata",
     "openstack/imageservice/v2/images",
+    "openstack/networking/v2/networks",
+    "openstack/networking/v2/subnets",
     "openstack/utils",
     "pagination",
   ]
-  pruneopts = ""
-  revision = "892256c468586d66a6864daeee52441afc0f7e38"
+  pruneopts = "UT"
+  revision = "a30f18a1bae0666be1434b31969c8e2702a2ad14"
 
 [[projects]]
   branch = "master"
-  digest = "1:4fe55793760295fbef367890352b720784243e0ad19b5ee242519a4682bb9ef8"
+  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
   branch = "master"
-  digest = "1:0b5ca7d18e4ded1e4dacbb37ff027cb40a80c0fed969e4e03cf7aff129bc1b44"
+  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
 
 [[projects]]
-  digest = "1:550e69376be9a028e7a039090d635e949134873c651a74a95a8896552db372b8"
+  digest = "1:1b626a9a3dc9490e97cf64bd3eba87da729b95be0383dda9d0d59fd8ba5da3cf"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:83854f6b1d2ce047b69657e3a87ba7602f4c5505e8bdfd02ab857db8e983bde1"
+  digest = "1:c7354463195544b1ab3c1f1fadb41430947f5d28dfbf2cdbd38268c5717a5a03"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "58046073cbffe2f25d425fe1331102f55cf719de"
 
 [[projects]]
-  digest = "1:32b27072cd55bd2fb7244de0425943d125da6a552ae2b6517cdd965a662baf18"
+  digest = "1:f4cbb10407f60c0263738e7b219b80ba99516aa9da187f44680d5b29360b3c9f"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -219,12 +222,12 @@
     "reporters/stenographer/support/go-isatty",
     "types",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:a4e59d0b2821c983b58c317f141cd77df20570979632da8a7a352e5d12698de7"
+  digest = "1:3f33175654fb22600581d63dbbb5098a2095d19423a8d180c0c92f55755f68dd"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -240,13 +243,13 @@
     "matchers/support/goraph/util",
     "types",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:df35603813d8bed7dcf0d5fee925e5fa6f1092f508a8389fe1c2eadd2bacb648"
+  digest = "1:0aae703a561b96d77966f883c9bc03cf43ccbb7d369e6b6222be5eb3782c4fe3"
   name = "github.com/vmware/go-vmware-nsxt"
   packages = [
     ".",
@@ -267,11 +270,11 @@
     "trust",
     "upgrade",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "23af5e753efe280311318a7b4f3b9525c838da2e"
 
 [[projects]]
-  digest = "1:3d7ab6845a1dbef8525ec93a71015634a3b5401df5c21726cb524c1c53572499"
+  digest = "1:a9eb9dc9de7012f490027b2286da9a90541678502d128318610e35da09df6f59"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -291,13 +294,13 @@
     "vim25/types",
     "vim25/xml",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "58d927a6c3241af7f51cff7915920a616b7af3ee"
   version = "v0.17.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:950b672f2ee80d0fc4c95a15a976ba9ee573a6fb8ede8a777770b2230776367e"
+  digest = "1:76552e2648d2e72fb07ea84a1fff171c18ccc28f9165757f2ab99a0ca93f3b5e"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -306,12 +309,12 @@
     "html/atom",
     "html/charset",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "dc871a5d77e227f5bbf6545176ef3eeebf87e76e"
 
 [[projects]]
   branch = "master"
-  digest = "1:32312c08bca1ac31103ee0aa3346bd4387d7a5f9b5e2e901c24f775df08bb82e"
+  digest = "1:f425fcb5bf3367e9e2223c9ea1396db3bd3f5e15990ae71037f8e170dc5e9b64"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -320,20 +323,20 @@
     "jws",
     "jwt",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "dfbc86644130ce8e95021c2c5b424bf5d76274a7"
 
 [[projects]]
   branch = "master"
-  digest = "1:5da11ab130476e2736f32140f3c1aed2a3a96e9ba8963711a7d38db783d042bd"
+  digest = "1:dbeb68e1adb188a04a049b3f755b0b4156321a51dcc252addf485a62198f1743"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "a0f4589a76f1f83070cb9e5613809e1d07b97c13"
 
 [[projects]]
   branch = "master"
-  digest = "1:1c70f7bb89783a026dc32920575a3feef48e065ef6e170ad227903e8194d7a36"
+  digest = "1:40f4ee1052120cc04a0eb9ef2ae79e6cb9fbe31ffa8f05bf8c36928b3c50af77"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -354,12 +357,12 @@
     "transform",
     "unicode/cldr",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "be25de41fadfae372d6470bda81ca6beb55ef551"
 
 [[projects]]
   branch = "master"
-  digest = "1:2e9f368cbaee698d59ee0eb86865378cc08e56f32b242ae8312c83a6101ff7cc"
+  digest = "1:e0015f04336aab40454b394ff37415e45e1aaa511c6ac9cf1ae0c0f20ab21506"
   name = "google.golang.org/api"
   packages = [
     "cloudresourcemanager/v1",
@@ -373,11 +376,11 @@
     "sqladmin/v1beta4",
     "storage/v1",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "f4694fe510ef1f58a08157aa15e795ffea4d4766"
 
 [[projects]]
-  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
+  digest = "1:a48f97fb737d5d61cf13e81cfef040942d217d086766b823757d39d4f6a4c547"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -391,16 +394,16 @@
     "internal/urlfetch",
     "urlfetch",
   ]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "v2"
-  digest = "1:f769ed60e075e4221612c2f4162fccc9d3795ef358fa463425e3b3d7a5debb27"
+  digest = "1:c46d0fb245dbc49cb816b3e2818d1830e29d03bee1663b1e201f3ed918ec6e60"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
+  pruneopts = "UT"
   revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [solve-meta]
@@ -430,10 +433,12 @@
     "github.com/gophercloud/gophercloud",
     "github.com/gophercloud/gophercloud/openstack",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-    "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
     "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
     "github.com/gophercloud/gophercloud/pagination",
     "github.com/hashicorp/go-multierror",
     "github.com/jessevdk/go-flags",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,4 +20,5 @@
 #  version = "2.4.0"
 
 [prune]
+  go-tests = true
   unused-packages = true

--- a/openstack/leftovers.go
+++ b/openstack/leftovers.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/genevieve/leftovers/app"
@@ -78,8 +79,12 @@ func NewLeftovers(logger logger, authArgs AuthArgs) (Leftovers, error) {
 		logger:       logger,
 		asyncDeleter: app.NewAsyncDeleter(logger),
 		resources: []listTyper{
-			NewVolumes(NewVolumesBlockStorageClient(VolumesAPI{serviceClient: serviceBS}), logger),
 			NewComputeInstances(NewComputeInstanceClient(ComputeAPI{serviceClient: serviceComputeInstance}), logger),
+			NewVolumes(NewVolumesBlockStorageClient(VolumesAPI{
+				serviceClient: serviceBS,
+				waitTime:      200 * time.Millisecond,
+				maxRetries:    50,
+			}), logger),
 			NewImages(NewImagesClient(ImageAPI{serviceClient: serviceImages}), logger),
 		}}, nil
 }

--- a/openstack/volume_api.go
+++ b/openstack/volume_api.go
@@ -1,6 +1,9 @@
 package openstack
 
 import (
+	"errors"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -8,6 +11,8 @@ import (
 
 type VolumesAPI struct {
 	serviceClient *gophercloud.ServiceClient
+	waitTime      time.Duration
+	maxRetries    int
 }
 
 func (api VolumesAPI) GetVolumesPager() pagination.Pager {
@@ -23,5 +28,35 @@ func (api VolumesAPI) PageToVolumes(page pagination.Page) ([]volumes.Volume, err
 }
 
 func (api VolumesAPI) DeleteVolume(id string) error {
+	var retries int
+
+	for {
+		volume, err := getVolume(api.serviceClient, id)
+		if err != nil {
+			return err
+		}
+
+		status := volume.Status
+		if status == "available" || status == "error" || status == "error_restoring" || status == "error_extending" || status == "error_managing" {
+			break
+		}
+
+		if retries == api.maxRetries {
+			return errors.New("volume failed to reach desired state")
+		}
+
+		retries++
+		time.Sleep(api.waitTime)
+	}
+
 	return volumes.Delete(api.serviceClient, id, volumes.DeleteOpts{}).ExtractErr()
+}
+
+func getVolume(serviceClient *gophercloud.ServiceClient, id string) (*volumes.Volume, error) {
+	volume, err := volumes.Get(serviceClient, id).Extract()
+	if err != nil {
+		return &volumes.Volume{}, err
+	}
+
+	return volume, nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/.travis.yml
+++ b/vendor/github.com/gophercloud/gophercloud/.travis.yml
@@ -9,6 +9,7 @@ install:
 go:
 - "1.10"
 - "1.11"
+- "1.12"
 - "tip"
 env:
   global:

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -14,6 +14,13 @@
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
 
 - job:
+    name: gophercloud-acceptance-test-ironic
+    parent: golang-test
+    description: |
+      Run gophercloud ironic acceptance test on master branch
+    run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
+
+- job:
     name: gophercloud-acceptance-test-queens
     parent: gophercloud-acceptance-test
     description: |
@@ -74,6 +81,7 @@
       jobs:
         - gophercloud-unittest
         - gophercloud-acceptance-test
+        - gophercloud-acceptance-test-ironic
     recheck-mitaka:
       jobs:
         - gophercloud-acceptance-test-mitaka

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -122,6 +122,11 @@ type ErrDefault408 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault409 is the default error type returned on a 409 HTTP response code.
+type ErrDefault409 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault429 is the default error type returned on a 429 HTTP response code.
 type ErrDefault429 struct {
 	ErrUnexpectedResponseCode
@@ -209,6 +214,12 @@ type Err405er interface {
 // from a 408 error.
 type Err408er interface {
 	Error408(ErrUnexpectedResponseCode) error
+}
+
+// Err409er is the interface resource error types implement to override the error message
+// from a 409 error.
+type Err409er interface {
+	Error409(ErrUnexpectedResponseCode) error
 }
 
 // Err429er is the interface resource error types implement to override the error message

--- a/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
@@ -13,15 +13,19 @@ AuthOptionsFromEnv fills out an identity.AuthOptions structure with the
 settings found on the various OpenStack OS_* environment variables.
 
 The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
-OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.
+OS_PASSWORD and OS_PROJECT_ID.
 
 Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must have settings,
-or an error will result.  OS_TENANT_ID, OS_TENANT_NAME, OS_PROJECT_ID, and
-OS_PROJECT_NAME are optional.
+or an error will result.  OS_PROJECT_ID, is optional.
 
-OS_TENANT_ID and OS_TENANT_NAME are mutually exclusive to OS_PROJECT_ID and
-OS_PROJECT_NAME. If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will
-still be referred as "tenant" in Gophercloud.
+OS_TENANT_ID and OS_TENANT_NAME are deprecated forms of OS_PROJECT_ID and
+OS_PROJECT_NAME and the latter are expected against a v3 auth api.
+
+If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will still be referred
+as "tenant" in Gophercloud.
+
+If OS_PROJECT_NAME is set, it requires OS_PROJECT_ID to be set as well to
+handle projects not on the default domain.
 
 To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
@@ -79,6 +83,13 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	if (applicationCredentialID != "" || applicationCredentialName != "") && applicationCredentialSecret == "" {
 		err := gophercloud.ErrMissingEnvironmentVariable{
 			EnvironmentVariable: "OS_APPLICATION_CREDENTIAL_SECRET",
+		}
+		return nilOptions, err
+	}
+
+	if domainID == "" && domainName == "" && tenantID == "" && tenantName != "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_PROJECT_ID",
 		}
 		return nilOptions, err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
@@ -77,6 +77,8 @@ type Volume struct {
 	ConsistencyGroupID string `json:"consistencygroup_id"`
 	// Multiattach denotes if the volume is multi-attach capable.
 	Multiattach bool `json:"multiattach"`
+	// Image metadata entries, only included for volumes that were created from an image, or from a snapshot of a volume originally created from an image.
+	VolumeImageMetadata map[string]string `json:"volume_image_metadata"`
 }
 
 // UnmarshalJSON another unmarshalling function

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -310,6 +310,12 @@ func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	return initClientOpts(client, eo, "baremetal")
 }
 
+// NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
+// bare metal introspection package.
+func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal-inspector")
+}
+
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/doc.go
@@ -1,0 +1,30 @@
+/*
+Package volumeattach provides the ability to attach and detach volumes
+from servers.
+
+Example to Attach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	volumeID := "87463836-f0e2-4029-abf6-20c8892a3103"
+
+	createOpts := volumeattach.CreateOpts{
+		Device:   "/dev/vdc",
+		VolumeID: volumeID,
+	}
+
+	result, err := volumeattach.Create(computeClient, serverID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Detach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	attachmentID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
+
+	err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package volumeattach

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -1,0 +1,60 @@
+package volumeattach
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List returns a Pager that allows you to iterate over a collection of
+// VolumeAttachments.
+func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+	return pagination.NewPager(client, listURL(client, serverID), func(r pagination.PageResult) pagination.Page {
+		return VolumeAttachmentPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToVolumeAttachmentCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies volume attachment creation or import parameters.
+type CreateOpts struct {
+	// Device is the device that the volume will attach to the instance as.
+	// Omit for "auto".
+	Device string `json:"device,omitempty"`
+
+	// VolumeID is the ID of the volume to attach to the instance.
+	VolumeID string `json:"volumeId" required:"true"`
+}
+
+// ToVolumeAttachmentCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToVolumeAttachmentCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volumeAttachment")
+}
+
+// Create requests the creation of a new volume attachment on the server.
+func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeAttachmentCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client, serverID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get returns public data about a previously created VolumeAttachment.
+func Get(client *gophercloud.ServiceClient, serverID, attachmentID string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, serverID, attachmentID), &r.Body, nil)
+	return
+}
+
+// Delete requests the deletion of a previous stored VolumeAttachment from
+// the server.
+func Delete(client *gophercloud.ServiceClient, serverID, attachmentID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, serverID, attachmentID), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/results.go
@@ -1,0 +1,77 @@
+package volumeattach
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// VolumeAttachment contains attachment information between a volume
+// and server.
+type VolumeAttachment struct {
+	// ID is a unique id of the attachment.
+	ID string `json:"id"`
+
+	// Device is what device the volume is attached as.
+	Device string `json:"device"`
+
+	// VolumeID is the ID of the attached volume.
+	VolumeID string `json:"volumeId"`
+
+	// ServerID is the ID of the instance that has the volume attached.
+	ServerID string `json:"serverId"`
+}
+
+// VolumeAttachmentPage stores a single page all of VolumeAttachment
+// results from a List call.
+type VolumeAttachmentPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a VolumeAttachmentPage is empty.
+func (page VolumeAttachmentPage) IsEmpty() (bool, error) {
+	va, err := ExtractVolumeAttachments(page)
+	return len(va) == 0, err
+}
+
+// ExtractVolumeAttachments interprets a page of results as a slice of
+// VolumeAttachment.
+func ExtractVolumeAttachments(r pagination.Page) ([]VolumeAttachment, error) {
+	var s struct {
+		VolumeAttachments []VolumeAttachment `json:"volumeAttachments"`
+	}
+	err := (r.(VolumeAttachmentPage)).ExtractInto(&s)
+	return s.VolumeAttachments, err
+}
+
+// VolumeAttachmentResult is the result from a volume attachment operation.
+type VolumeAttachmentResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any VolumeAttachment resource
+// response as a VolumeAttachment struct.
+func (r VolumeAttachmentResult) Extract() (*VolumeAttachment, error) {
+	var s struct {
+		VolumeAttachment *VolumeAttachment `json:"volumeAttachment"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VolumeAttachment, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a VolumeAttachment.
+type CreateResult struct {
+	VolumeAttachmentResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a VolumeAttachment.
+type GetResult struct {
+	VolumeAttachmentResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach/urls.go
@@ -1,0 +1,25 @@
+package volumeattach
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "os-volume_attachments"
+
+func resourceURL(c *gophercloud.ServiceClient, serverID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func createURL(c *gophercloud.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func getURL(c *gophercloud.ServiceClient, serverID, aID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath, aID)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, serverID, aID string) string {
+	return getURL(c, serverID, aID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -148,7 +148,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// Get retrieves details of a single flavor. Use ExtractFlavor to convert its
+// Get retrieves details of a single flavor. Use Extract to convert its
 // result into a Flavor.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -183,8 +183,14 @@ type CreateOpts struct {
 	// AccessIPv4 specifies an IPv4 address for the instance.
 	AccessIPv4 string `json:"accessIPv4,omitempty"`
 
-	// AccessIPv6 pecifies an IPv6 address for the instance.
+	// AccessIPv6 specifies an IPv6 address for the instance.
 	AccessIPv6 string `json:"accessIPv6,omitempty"`
+
+	// Min specifies Minimum number of servers to launch.
+	Min int `json:"min_count,omitempty"`
+
+	// Max specifies Maximum number of servers to launch.
+	Max int `json:"max_count,omitempty"`
 
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
@@ -274,6 +280,14 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 			return nil, err
 		}
 		b["flavorRef"] = flavorID
+	}
+
+	if opts.Min != 0 {
+		b["min_count"] = opts.Min
+	}
+
+	if opts.Max != 0 {
+		b["max_count"] = opts.Max
 	}
 
 	return map[string]interface{}{"server": b}, nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/doc.go
@@ -1,0 +1,65 @@
+/*
+Package networks contains functionality for working with Neutron network
+resources. A network is an isolated virtual layer-2 broadcast domain that is
+typically reserved for the tenant who created it (unless you configure the
+network to be shared). Tenants can create multiple networks until the
+thresholds per-tenant quota is reached.
+
+In the v2.0 Networking API, the network is the main entity. Ports and subnets
+are always associated with a network.
+
+Example to List Networks
+
+	listOpts := networks.ListOpts{
+		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
+	}
+
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allNetworks, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Printf("%+v", network)
+	}
+
+Example to Create a Network
+
+	iTrue := true
+	createOpts := networks.CreateOpts{
+		Name:         "network_1",
+		AdminStateUp: &iTrue,
+	}
+
+	network, err := networks.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Network
+
+	networkID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+
+	updateOpts := networks.UpdateOpts{
+		Name: "new_name",
+	}
+
+	network, err := networks.Update(networkClient, networkID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Network
+
+	networkID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+	err := networks.Delete(networkClient, networkID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package networks

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -1,0 +1,180 @@
+package networks
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToNetworkListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network attributes you want to see returned. SortKey allows you to sort
+// by a particular network attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Status       string `q:"status"`
+	Name         string `q:"name"`
+	Description  string `q:"description"`
+	AdminStateUp *bool  `q:"admin_state_up"`
+	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
+	Shared       *bool  `q:"shared"`
+	ID           string `q:"id"`
+	Marker       string `q:"marker"`
+	Limit        int    `q:"limit"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
+}
+
+// ToNetworkListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// networks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToNetworkListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return NetworkPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific network based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToNetworkCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options used to create a network.
+type CreateOpts struct {
+	AdminStateUp          *bool    `json:"admin_state_up,omitempty"`
+	Name                  string   `json:"name,omitempty"`
+	Description           string   `json:"description,omitempty"`
+	Shared                *bool    `json:"shared,omitempty"`
+	TenantID              string   `json:"tenant_id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
+	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
+}
+
+// ToNetworkCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+// Create accepts a CreateOpts struct and creates a new network using the values
+// provided. This operation does not actually require a request body, i.e. the
+// CreateOpts struct argument can be empty.
+//
+// The tenant ID that is contained in the URI is the tenant that creates the
+// network. An admin user, however, has the option of specifying another tenant
+// ID in the CreateOpts struct.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToNetworkCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToNetworkUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a network.
+type UpdateOpts struct {
+	AdminStateUp *bool   `json:"admin_state_up,omitempty"`
+	Name         string  `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	Shared       *bool   `json:"shared,omitempty"`
+}
+
+// ToNetworkUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing network using the
+// values provided. For more information, see the Create function.
+func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToNetworkUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, networkID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the network associated with it.
+func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, networkID), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a network's ID, given
+// its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractNetworks(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "network"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "network"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -1,0 +1,124 @@
+package networks
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a network resource.
+func (r commonResult) Extract() (*Network, error) {
+	var s Network
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "network")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Network.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Network.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Network.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Network represents, well, a network.
+type Network struct {
+	// UUID for the network
+	ID string `json:"id"`
+
+	// Human-readable name for the network. Might not be unique.
+	Name string `json:"name"`
+
+	// Description for the network
+	Description string `json:"description"`
+
+	// The administrative state of network. If false (down), the network does not
+	// forward packets.
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Indicates whether network is currently operational. Possible values include
+	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional
+	// values.
+	Status string `json:"status"`
+
+	// Subnets associated with this network.
+	Subnets []string `json:"subnets"`
+
+	// TenantID is the project owner of the network.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the network.
+	ProjectID string `json:"project_id"`
+
+	// Specifies whether the network resource can be accessed by any tenant.
+	Shared bool `json:"shared"`
+
+	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
+	// Used to make network resources highly available.
+	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+// NetworkPage is the page returned by a pager when traversing over a
+// collection of networks.
+type NetworkPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of networks has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r NetworkPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"networks_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a NetworkPage struct is empty.
+func (r NetworkPage) IsEmpty() (bool, error) {
+	is, err := ExtractNetworks(r)
+	return len(is) == 0, err
+}
+
+// ExtractNetworks accepts a Page struct, specifically a NetworkPage struct,
+// and extracts the elements into a slice of Network structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractNetworks(r pagination.Page) ([]Network, error) {
+	var s []Network
+	err := ExtractNetworksInto(r, &s)
+	return s, err
+}
+
+func ExtractNetworksInto(r pagination.Page, v interface{}) error {
+	return r.(NetworkPage).Result.ExtractIntoSlicePtr(v, "networks")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/urls.go
@@ -1,0 +1,31 @@
+package networks
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("networks", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("networks")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/doc.go
@@ -1,0 +1,133 @@
+/*
+Package subnets contains functionality for working with Neutron subnet
+resources. A subnet represents an IP address block that can be used to
+assign IP addresses to virtual instances. Each subnet must have a CIDR and
+must be associated with a network. IPs can either be selected from the whole
+subnet CIDR or from allocation pools specified by the user.
+
+A subnet can also have a gateway, a list of DNS name servers, and host routes.
+This information is pushed to instances whose interfaces are associated with
+the subnet.
+
+Example to List Subnets
+
+	listOpts := subnets.ListOpts{
+		IPVersion: 4,
+	}
+
+	allPages, err := subnets.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allSubnets, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, subnet := range allSubnets {
+		fmt.Printf("%+v\n", subnet)
+	}
+
+Example to Create a Subnet With Specified Gateway
+
+	var gatewayIP = "192.168.199.1"
+	createOpts := subnets.CreateOpts{
+		NetworkID: "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+		IPVersion: 4,
+		CIDR:      "192.168.199.0/24",
+		GatewayIP: &gatewayIP,
+		AllocationPools: []subnets.AllocationPool{
+		  {
+		    Start: "192.168.199.2",
+		    End:   "192.168.199.254",
+		  },
+		},
+		DNSNameservers: []string{"foo"},
+	}
+
+	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Subnet With No Gateway
+
+	var noGateway = ""
+
+	createOpts := subnets.CreateOpts{
+		NetworkID: "d32019d3-bc6e-4319-9c1d-6722fc136a23",
+		IPVersion: 4,
+		CIDR:      "192.168.1.0/24",
+		GatewayIP: &noGateway,
+		AllocationPools: []subnets.AllocationPool{
+			{
+				Start: "192.168.1.2",
+				End:   "192.168.1.254",
+			},
+		},
+		DNSNameservers: []string{},
+	}
+
+	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Subnet With a Default Gateway
+
+	createOpts := subnets.CreateOpts{
+		NetworkID: "d32019d3-bc6e-4319-9c1d-6722fc136a23",
+		IPVersion: 4,
+		CIDR:      "192.168.1.0/24",
+		AllocationPools: []subnets.AllocationPool{
+			{
+				Start: "192.168.1.2",
+				End:   "192.168.1.254",
+			},
+		},
+		DNSNameservers: []string{},
+	}
+
+	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Subnet
+
+	subnetID := "db77d064-e34f-4d06-b060-f21e28a61c23"
+
+	updateOpts := subnets.UpdateOpts{
+		Name:           "new_name",
+		DNSNameservers: []string{"8.8.8.8},
+	}
+
+	subnet, err := subnets.Update(networkClient, subnetID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove a Gateway From a Subnet
+
+	var noGateway = ""
+	subnetID := "db77d064-e34f-4d06-b060-f21e28a61c23"
+
+	updateOpts := subnets.UpdateOpts{
+		GatewayIP: &noGateway,
+	}
+
+	subnet, err := subnets.Update(networkClient, subnetID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Subnet
+
+	subnetID := "db77d064-e34f-4d06-b060-f21e28a61c23"
+	err := subnets.Delete(networkClient, subnetID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package subnets

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -1,0 +1,269 @@
+package subnets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToSubnetListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the subnet attributes you want to see returned. SortKey allows you to sort
+// by a particular subnet attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Name            string `q:"name"`
+	Description     string `q:"description"`
+	EnableDHCP      *bool  `q:"enable_dhcp"`
+	NetworkID       string `q:"network_id"`
+	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
+	IPVersion       int    `q:"ip_version"`
+	GatewayIP       string `q:"gateway_ip"`
+	CIDR            string `q:"cidr"`
+	IPv6AddressMode string `q:"ipv6_address_mode"`
+	IPv6RAMode      string `q:"ipv6_ra_mode"`
+	ID              string `q:"id"`
+	SubnetPoolID    string `q:"subnetpool_id"`
+	Limit           int    `q:"limit"`
+	Marker          string `q:"marker"`
+	SortKey         string `q:"sort_key"`
+	SortDir         string `q:"sort_dir"`
+	Tags            string `q:"tags"`
+	TagsAny         string `q:"tags-any"`
+	NotTags         string `q:"not-tags"`
+	NotTagsAny      string `q:"not-tags-any"`
+}
+
+// ToSubnetListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSubnetListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// subnets. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those subnets that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToSubnetListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return SubnetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific subnet based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type CreateOptsBuilder interface {
+	ToSubnetCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents the attributes used when creating a new subnet.
+type CreateOpts struct {
+	// NetworkID is the UUID of the network the subnet will be associated with.
+	NetworkID string `json:"network_id" required:"true"`
+
+	// CIDR is the address CIDR of the subnet.
+	CIDR string `json:"cidr,omitempty"`
+
+	// Name is a human-readable name of the subnet.
+	Name string `json:"name,omitempty"`
+
+	// Description of the subnet.
+	Description string `json:"description,omitempty"`
+
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// AllocationPools are IP Address pools that will be available for DHCP.
+	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
+
+	// GatewayIP sets gateway information for the subnet. Setting to nil will
+	// cause a default gateway to automatically be created. Setting to an empty
+	// string will cause the subnet to be created with no gateway. Setting to
+	// an explicit address will set that address as the gateway.
+	GatewayIP *string `json:"gateway_ip,omitempty"`
+
+	// IPVersion is the IP version for the subnet.
+	IPVersion gophercloud.IPVersion `json:"ip_version,omitempty"`
+
+	// EnableDHCP will either enable to disable the DHCP service.
+	EnableDHCP *bool `json:"enable_dhcp,omitempty"`
+
+	// DNSNameservers are the nameservers to be set via DHCP.
+	DNSNameservers []string `json:"dns_nameservers,omitempty"`
+
+	// HostRoutes are any static host routes to be set via DHCP.
+	HostRoutes []HostRoute `json:"host_routes,omitempty"`
+
+	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
+	IPv6AddressMode string `json:"ipv6_address_mode,omitempty"`
+
+	// The IPv6 router advertisement specifies whether the networking service
+	// should transmit ICMPv6 packets.
+	IPv6RAMode string `json:"ipv6_ra_mode,omitempty"`
+
+	// SubnetPoolID is the id of the subnet pool that subnet should be associated to.
+	SubnetPoolID string `json:"subnetpool_id,omitempty"`
+
+	// Prefixlen is used when user creates a subnet from the subnetpool. It will
+	// overwrite the "default_prefixlen" value of the referenced subnetpool.
+	Prefixlen int `json:"prefixlen,omitempty"`
+}
+
+// ToSubnetCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "subnet")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["subnet"].(map[string]interface{}); m["gateway_ip"] == "" {
+		m["gateway_ip"] = nil
+	}
+
+	return b, nil
+}
+
+// Create accepts a CreateOpts struct and creates a new subnet using the values
+// provided. You must remember to provide a valid NetworkID, CIDR and IP
+// version.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSubnetCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSubnetUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents the attributes used when updating an existing subnet.
+type UpdateOpts struct {
+	// Name is a human-readable name of the subnet.
+	Name string `json:"name,omitempty"`
+
+	// Description of the subnet.
+	Description *string `json:"description,omitempty"`
+
+	// AllocationPools are IP Address pools that will be available for DHCP.
+	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
+
+	// GatewayIP sets gateway information for the subnet. Setting to nil will
+	// cause a default gateway to automatically be created. Setting to an empty
+	// string will cause the subnet to be created with no gateway. Setting to
+	// an explicit address will set that address as the gateway.
+	GatewayIP *string `json:"gateway_ip,omitempty"`
+
+	// DNSNameservers are the nameservers to be set via DHCP.
+	DNSNameservers []string `json:"dns_nameservers,omitempty"`
+
+	// HostRoutes are any static host routes to be set via DHCP.
+	HostRoutes *[]HostRoute `json:"host_routes,omitempty"`
+
+	// EnableDHCP will either enable to disable the DHCP service.
+	EnableDHCP *bool `json:"enable_dhcp,omitempty"`
+}
+
+// ToSubnetUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToSubnetUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "subnet")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["subnet"].(map[string]interface{}); m["gateway_ip"] == "" {
+		m["gateway_ip"] = nil
+	}
+
+	return b, nil
+}
+
+// Update accepts a UpdateOpts struct and updates an existing subnet using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSubnetUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the subnet associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a subnet's ID,
+// given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSubnets(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "subnet"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "subnet"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
@@ -1,0 +1,152 @@
+package subnets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a subnet resource.
+func (r commonResult) Extract() (*Subnet, error) {
+	var s struct {
+		Subnet *Subnet `json:"subnet"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Subnet, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Subnet.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Subnet.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Subnet.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// AllocationPool represents a sub-range of cidr available for dynamic
+// allocation to ports, e.g. {Start: "10.0.0.2", End: "10.0.0.254"}
+type AllocationPool struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// HostRoute represents a route that should be used by devices with IPs from
+// a subnet (not including local subnet route).
+type HostRoute struct {
+	DestinationCIDR string `json:"destination"`
+	NextHop         string `json:"nexthop"`
+}
+
+// Subnet represents a subnet. See package documentation for a top-level
+// description of what this is.
+type Subnet struct {
+	// UUID representing the subnet.
+	ID string `json:"id"`
+
+	// UUID of the parent network.
+	NetworkID string `json:"network_id"`
+
+	// Human-readable name for the subnet. Might not be unique.
+	Name string `json:"name"`
+
+	// Description for the subnet.
+	Description string `json:"description"`
+
+	// IP version, either `4' or `6'.
+	IPVersion int `json:"ip_version"`
+
+	// CIDR representing IP range for this subnet, based on IP version.
+	CIDR string `json:"cidr"`
+
+	// Default gateway used by devices in this subnet.
+	GatewayIP string `json:"gateway_ip"`
+
+	// DNS name servers used by hosts in this subnet.
+	DNSNameservers []string `json:"dns_nameservers"`
+
+	// Sub-ranges of CIDR available for dynamic allocation to ports.
+	// See AllocationPool.
+	AllocationPools []AllocationPool `json:"allocation_pools"`
+
+	// Routes that should be used by devices with IPs from this subnet
+	// (not including local subnet route).
+	HostRoutes []HostRoute `json:"host_routes"`
+
+	// Specifies whether DHCP is enabled for this subnet or not.
+	EnableDHCP bool `json:"enable_dhcp"`
+
+	// TenantID is the project owner of the subnet.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the subnet.
+	ProjectID string `json:"project_id"`
+
+	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
+	IPv6AddressMode string `json:"ipv6_address_mode"`
+
+	// The IPv6 router advertisement specifies whether the networking service
+	// should transmit ICMPv6 packets.
+	IPv6RAMode string `json:"ipv6_ra_mode"`
+
+	// SubnetPoolID is the id of the subnet pool associated with the subnet.
+	SubnetPoolID string `json:"subnetpool_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+// SubnetPage is the page returned by a pager when traversing over a collection
+// of subnets.
+type SubnetPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of subnets has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r SubnetPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"subnets_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SubnetPage struct is empty.
+func (r SubnetPage) IsEmpty() (bool, error) {
+	is, err := ExtractSubnets(r)
+	return len(is) == 0, err
+}
+
+// ExtractSubnets accepts a Page struct, specifically a SubnetPage struct,
+// and extracts the elements into a slice of Subnet structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractSubnets(r pagination.Page) ([]Subnet, error) {
+	var s struct {
+		Subnets []Subnet `json:"subnets"`
+	}
+	err := (r.(SubnetPage)).ExtractInto(&s)
+	return s.Subnets, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/urls.go
@@ -1,0 +1,31 @@
+package subnets
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("subnets", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("subnets")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -2,6 +2,7 @@ package gophercloud
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -76,13 +77,21 @@ type ProviderClient struct {
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
 	Throwaway bool
 
+	// Context is the context passed to the HTTP request.
+	Context context.Context
+
+	// mut is a mutex for the client. It protects read and write access to client attributes such as getting
+	// and setting the TokenID.
 	mut *sync.RWMutex
 
+	// reauthmut is a mutex for reauthentication it attempts to ensure that only one reauthentication
+	// attempt happens at one time.
 	reauthmut *reauthlock
 
 	authResult AuthResult
 }
 
+// reauthlock represents a set of attributes used to help in the reauthentication process.
 type reauthlock struct {
 	sync.RWMutex
 	reauthing    bool
@@ -219,7 +228,7 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return nil
 	}
 
-	if client.mut == nil {
+	if client.reauthmut == nil {
 		return client.ReauthFunc()
 	}
 
@@ -233,9 +242,6 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return err
 	}
 	client.reauthmut.Unlock()
-
-	client.mut.Lock()
-	defer client.mut.Unlock()
 
 	client.reauthmut.Lock()
 	client.reauthmut.reauthing = true
@@ -311,6 +317,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
+	}
+	if client.Context != nil {
+		req = req.WithContext(client.Context)
 	}
 
 	// Populate the request headers. Apply options.MoreHeaders last, to give the caller the chance to
@@ -433,6 +442,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			err = ErrDefault408{respErr}
 			if error408er, ok := errType.(Err408er); ok {
 				err = error408er.Error408(respErr)
+			}
+		case http.StatusConflict:
+			err = ErrDefault409{respErr}
+			if error409er, ok := errType.(Err409er); ok {
+				err = error409er.Error409(respErr)
 			}
 		case 429:
 			err = ErrDefault429{respErr}

--- a/vendor/github.com/gophercloud/gophercloud/service_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/service_client.go
@@ -131,6 +131,8 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
 	case "baremetal":
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
+	case "baremetal-introspection":
+		opts.MoreHeaders["X-OpenStack-Ironic-Inspector-API-Version"] = client.Microversion
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
- We delete compute instances (aka servers) first then volumes so that they're orphaned
- We wait until the volume is in a deletable status before deleting

Signed-off-by: Nick Rohn <nrohn@pivotal.io>