### PR TITLE
Debug mode

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -46,14 +46,28 @@ export LEFTOVERS_ACCEPTANCE=azure
 ginkgo -r -p -race acceptance
 ```
 
-### WMware vSphere
+### VMware vSphere
 
 ```bash
 export BBL_VSPHERE_VCENTER_IP=
 export BBL_VSPHERE_VCENTER_PASSWORD=
 export BBL_VSPHERE_VCENTER_USER=
 export BBL_VSPHERE_VCENTER_DC=
+export BBL_VSPHERE_VCENTER_DS=
+export BBL_VSPHERE_VCENTER_RP=
 export LEFTOVERS_ACCEPTANCE=vsphere
+
+ginkgo -r -p -race acceptance
+```
+
+### VMware NSX-T
+
+```bash
+export NSXT_MANAGER_HOST=
+export NSXT_PASSWORD=
+export NSXT_USER=
+export NSXT_EDGE_CLUSTER=
+export LEFTOVERS_ACCEPTANCE=nsxt
 
 ginkgo -r -p -race acceptance
 ```

--- a/acceptance/aws.go
+++ b/acceptance/aws.go
@@ -38,7 +38,7 @@ func NewAWSAcceptance() AWSAcceptance {
 		SecretAccessKey: secretAccessKey,
 		SessionToken:    sessionToken,
 		Region:          region,
-		Logger:          app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:          app.NewLogger(os.Stdin, os.Stdout, true, false),
 	}
 }
 

--- a/acceptance/aws_test.go
+++ b/acceptance/aws_test.go
@@ -31,8 +31,9 @@ var _ = Describe("AWS", func() {
 		acc = NewAWSAcceptance()
 
 		noConfirm := true
+		debug := false
 		stdout = bytes.NewBuffer([]byte{})
-		logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
 		var err error
 		deleter, err = aws.NewLeftovers(logger, acc.AccessKeyId, acc.SecretAccessKey, acc.SessionToken, acc.Region)

--- a/acceptance/azure.go
+++ b/acceptance/azure.go
@@ -38,7 +38,7 @@ func NewAzureAcceptance() AzureAcceptance {
 		TenantId:       tenantId,
 		ClientId:       clientId,
 		ClientSecret:   clientSecret,
-		Logger:         app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:         app.NewLogger(os.Stdin, os.Stdout, true, false),
 	}
 }
 

--- a/acceptance/azure_test.go
+++ b/acceptance/azure_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Azure", func() {
 		acc = NewAzureAcceptance()
 
 		noConfirm := true
-		debug := false
+		debug := true
 		stdout = bytes.NewBuffer([]byte{})
 		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
@@ -56,6 +56,7 @@ var _ = Describe("Azure", func() {
 			deleter.List(filter)
 
 			Expect(stdout.String()).To(ContainSubstring("[Resource Group: %s]", filter))
+			Expect(stdout.String()).To(ContainSubstring("Listing Resource Groups..."))
 			Expect(stdout.String()).NotTo(ContainSubstring("[Resource Group: %s] Deleting...", filter))
 		})
 	})

--- a/acceptance/azure_test.go
+++ b/acceptance/azure_test.go
@@ -30,8 +30,9 @@ var _ = Describe("Azure", func() {
 		acc = NewAzureAcceptance()
 
 		noConfirm := true
+		debug := false
 		stdout = bytes.NewBuffer([]byte{})
-		logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
 		var err error
 		deleter, err = azure.NewLeftovers(logger, acc.ClientId, acc.ClientSecret, acc.SubscriptionId, acc.TenantId)

--- a/acceptance/gcp.go
+++ b/acceptance/gcp.go
@@ -45,7 +45,7 @@ func NewGCPAcceptance() GCPAcceptance {
 		ProjectId: p.ProjectId,
 		Zone:      "us-east1-b",
 		Region:    "us-east1",
-		Logger:    app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:    app.NewLogger(os.Stdin, os.Stdout, true, false),
 	}
 }
 

--- a/acceptance/gcp_test.go
+++ b/acceptance/gcp_test.go
@@ -30,8 +30,9 @@ var _ = Describe("GCP", func() {
 		acc = NewGCPAcceptance()
 
 		noConfirm := true
+		debug := true
 		stdout = bytes.NewBuffer([]byte{})
-		logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
 		var err error
 		deleter, err = gcp.NewLeftovers(logger, acc.KeyPath)
@@ -55,6 +56,7 @@ var _ = Describe("GCP", func() {
 			deleter.List(filter)
 
 			Expect(stdout.String()).To(ContainSubstring("[Disk: %s]", filter))
+			Expect(stdout.String()).To(ContainSubstring("Listing Disks for Zone"))
 			Expect(stdout.String()).NotTo(ContainSubstring("[Disk: %s] Deleting...", filter))
 		})
 	})

--- a/acceptance/nsxt.go
+++ b/acceptance/nsxt.go
@@ -53,7 +53,7 @@ func NewNSXTAcceptance() NSXTAcceptance {
 		Password:    nsxtPassword,
 		NSXTClient:  nsxtClient,
 		EdgeCluster: edgeCluster,
-		Logger:      app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:      app.NewLogger(os.Stdin, os.Stdout, true, false),
 	}
 }
 

--- a/acceptance/nsxt_test.go
+++ b/acceptance/nsxt_test.go
@@ -29,7 +29,7 @@ var _ = Describe("NSX-T", func() {
 		acc = NewNSXTAcceptance()
 
 		noConfirm := true
-		debug := false
+		debug := true
 		stdout = bytes.NewBuffer([]byte{})
 		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
@@ -50,6 +50,7 @@ var _ = Describe("NSX-T", func() {
 				deleter.List("leftover")
 				Expect(stdout.String()).NotTo(ContainSubstring("403"))
 
+				Expect(stdout.String()).To(ContainSubstring("Listing Tier 1 Routers..."))
 				Expect(stdout.String()).To(ContainSubstring("[Tier 1 Router: leftover-tier1-router]"))
 				Expect(stdout.String()).NotTo(ContainSubstring("[Tier 1 Router: leftover-tier1-router] Deleting"))
 			})

--- a/acceptance/nsxt_test.go
+++ b/acceptance/nsxt_test.go
@@ -29,8 +29,9 @@ var _ = Describe("NSX-T", func() {
 		acc = NewNSXTAcceptance()
 
 		noConfirm := true
+		debug := false
 		stdout = bytes.NewBuffer([]byte{})
-		logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
 		var err error
 		deleter, err = nsxt.NewLeftovers(logger, acc.ManagerHost, acc.User, acc.Password)

--- a/acceptance/openstack.go
+++ b/acceptance/openstack.go
@@ -50,7 +50,7 @@ func (t testResource) Delete() error {
 
 func NewOpenStackAcceptance() *OpenStackAcceptance {
 	return &OpenStackAcceptance{
-		Logger:      app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:      app.NewLogger(os.Stdin, os.Stdout, true, false),
 		AuthURL:     os.Getenv("BBL_OPENSTACK_AUTH_URL"),
 		Domain:      os.Getenv("BBL_OPENSTACK_DOMAIN"),
 		Username:    os.Getenv("BBL_OPENSTACK_USERNAME"),

--- a/acceptance/openstack_test.go
+++ b/acceptance/openstack_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Openstack", func() {
 
 			By("listing all resources when calling Types")
 			noConfirm := true
-			debug := false
+			debug := true
 			stdout = bytes.NewBuffer([]byte{})
 			logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 			leftovers, err = openstack.NewLeftovers(logger, openstack.AuthArgs{
@@ -83,6 +83,7 @@ var _ = Describe("Openstack", func() {
 			By("listing all resources when a filter isn't passed to List")
 			leftovers.List("")
 
+			Expect(stdout.String()).To(ContainSubstring("Listing Volumes..."))
 			Expect(stdout.String()).To(ContainSubstring(fmt.Sprintf("[Volume: %s %s]", "some volume", volumeID)))
 			Expect(stdout.String()).To(ContainSubstring(fmt.Sprintf("[Compute Instance: %s %s]", "some instance", instanceID)))
 			Expect(acc.VolumeExists(volumeID)).To(BeTrue())

--- a/acceptance/openstack_test.go
+++ b/acceptance/openstack_test.go
@@ -51,8 +51,9 @@ var _ = Describe("Openstack", func() {
 
 			By("listing all resources when calling Types")
 			noConfirm := true
+			debug := false
 			stdout = bytes.NewBuffer([]byte{})
-			logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+			logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 			leftovers, err = openstack.NewLeftovers(logger, openstack.AuthArgs{
 				AuthURL:    acc.AuthURL,
 				Username:   acc.Username,

--- a/acceptance/vsphere.go
+++ b/acceptance/vsphere.go
@@ -64,7 +64,7 @@ func NewVSphereAcceptance() VSphereAcceptance {
 		Datastore:       datastore,
 		ResourcePool:    resourcePool,
 		VCenterClient:   vimClient,
-		Logger:          app.NewLogger(os.Stdin, os.Stdout, true),
+		Logger:          app.NewLogger(os.Stdin, os.Stdout, true, false),
 	}
 }
 

--- a/acceptance/vsphere.go
+++ b/acceptance/vsphere.go
@@ -44,7 +44,7 @@ func NewVSphereAcceptance() VSphereAcceptance {
 	Expect(datastore).NotTo(Equal(""), "Missing $BBL_VSPHERE_VCENTER_DS.")
 
 	resourcePool := os.Getenv("BBL_VSPHERE_VCENTER_RP")
-	Expect(datastore).NotTo(Equal(""), "Missing $BBL_VSPHERE_VCENTER_RP.")
+	Expect(resourcePool).NotTo(Equal(""), "Missing $BBL_VSPHERE_VCENTER_RP.")
 
 	vCenterUrl, err := url.Parse("https://" + vcenterIP + "/sdk")
 	Expect(err).NotTo(HaveOccurred())

--- a/acceptance/vsphere_test.go
+++ b/acceptance/vsphere_test.go
@@ -35,8 +35,9 @@ var _ = Describe("vSphere", func() {
 		acc = NewVSphereAcceptance()
 
 		noConfirm := true
+		debug := false
 		stdout = bytes.NewBuffer([]byte{})
-		logger := app.NewLogger(stdout, os.Stdin, noConfirm)
+		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
 		var err error
 		deleter, err = vsphere.NewLeftovers(logger, acc.VCenterIP, acc.VCenterUser, acc.VCenterPassword, acc.Datacenter)

--- a/acceptance/vsphere_test.go
+++ b/acceptance/vsphere_test.go
@@ -29,13 +29,13 @@ var _ = Describe("vSphere", func() {
 		}
 		filter = os.Getenv("LEFTOVERS_VSPHERE_FILTER")
 		if filter == "" {
-			filter = "khaleesi"
+			filter = "eevee" // use the Toolsmiths team's test resource pool
 		}
 
 		acc = NewVSphereAcceptance()
 
 		noConfirm := true
-		debug := false
+		debug := true
 		stdout = bytes.NewBuffer([]byte{})
 		logger := app.NewLogger(stdout, os.Stdin, noConfirm, debug)
 
@@ -65,6 +65,7 @@ var _ = Describe("vSphere", func() {
 				Expect(stdout.String()).To(ContainSubstring("[Virtual Machine: leftover-vm]"))
 				Expect(stdout.String()).To(ContainSubstring("[Virtual Machine: leftover-nested-vm]"))
 				Expect(stdout.String()).To(ContainSubstring("[Virtual Machine: leftover-twice-nested-vm]"))
+				Expect(stdout.String()).To(ContainSubstring("Listing children of folder leftovers-acceptance..."))
 				Expect(stdout.String()).NotTo(ContainSubstring("[Virtual Machine: leftover-vm] Deleting..."))
 				Expect(stdout.String()).NotTo(ContainSubstring("[Virtual Machine: leftover-nested-vm] Deleting..."))
 				Expect(stdout.String()).NotTo(ContainSubstring("[Virtual Machine: leftover-twice-nested-vm] Deleting..."))

--- a/app/env_vars.go
+++ b/app/env_vars.go
@@ -10,6 +10,7 @@ type Options struct {
 	DryRun    bool   `short:"d"  long:"dry-run"                     description:"List all resources without deleting any."`
 	Filter    string `short:"f"  long:"filter"                      description:"Filtering resources by an environment name."`
 	Type      string `short:"t"  long:"type"                        description:"Type of resource to delete."`
+	Debug     string `           long:"debug"                       description:"Print debug information."`
 
 	AWSAccessKeyID       string `long:"aws-access-key-id"        env:"BBL_AWS_ACCESS_KEY_ID"        description:"AWS access key id."`
 	AWSSecretAccessKey   string `long:"aws-secret-access-key"    env:"BBL_AWS_SECRET_ACCESS_KEY"    description:"AWS secret access key."`

--- a/app/logger.go
+++ b/app/logger.go
@@ -13,17 +13,19 @@ type Logger struct {
 	mutex     *sync.Mutex
 	reader    io.Reader
 	noConfirm bool
+	debug     bool
 }
 
 // NewLogger returns a new Logger with the provided writer,
 // reader, and value of noConfirm.
-func NewLogger(writer io.Writer, reader io.Reader, noConfirm bool) *Logger {
+func NewLogger(writer io.Writer, reader io.Reader, noConfirm bool, debug bool) *Logger {
 	return &Logger{
 		newline:   true,
 		writer:    writer,
 		mutex:     &sync.Mutex{},
 		reader:    reader,
 		noConfirm: noConfirm,
+		debug:     debug,
 	}
 }
 
@@ -45,12 +47,34 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	fmt.Fprintf(l.writer, "%s", fmt.Sprintf(message, a...))
 }
 
+// Debugf handles arguments in the manner of fmt.Fprintf.
+// It only prints output in debug mode.
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.clear()
+	if l.debug {
+		fmt.Fprintf(l.writer, "%s", fmt.Sprintf(message, a...))
+	}
+}
+
 // Println handles the argument in the manner of fmt.Fprintln.
 func (l *Logger) Println(message string) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	l.clear()
 	fmt.Fprintln(l.writer, message)
+}
+
+// Debugln handles the argument in the manner of fmt.Fprintln.
+// It only prints output in debug mode.
+func (l *Logger) Debugln(message string) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.clear()
+	if l.debug {
+		fmt.Fprintln(l.writer, message)
+	}
 }
 
 // PromptWithDetails will block all other goroutines attempting

--- a/azure/app_security_groups.go
+++ b/azure/app_security_groups.go
@@ -27,6 +27,7 @@ func NewAppSecurityGroups(client appSecurityGroupsClient, rgName string, logger 
 }
 
 func (g AppSecurityGroups) List(filter string) ([]common.Deletable, error) {
+	g.logger.Debugln("Listing Application Security Groups")
 	groups, err := g.client.ListAppSecurityGroups(g.rgName)
 	if err != nil {
 		return nil, fmt.Errorf("Listing Application Security Groups: %s", err)

--- a/azure/fakes/logger.go
+++ b/azure/fakes/logger.go
@@ -18,6 +18,13 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -43,6 +50,12 @@ func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {
 	l.PromptWithDetailsCall.Receives.Name = resourceName
 
 	return l.PromptWithDetailsCall.Returns.Proceed
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) Println(message string) {

--- a/azure/groups.go
+++ b/azure/groups.go
@@ -25,6 +25,7 @@ func NewGroups(client groupsClient, logger logger) Groups {
 }
 
 func (g Groups) List(filter string) ([]common.Deletable, error) {
+	g.logger.Debugln("Listing Resource Groups")
 	groups, err := g.client.ListGroups()
 	if err != nil {
 		return []common.Deletable{}, fmt.Errorf("Listing Resource Groups: %s", err)

--- a/azure/logger.go
+++ b/azure/logger.go
@@ -2,7 +2,8 @@ package azure
 
 type logger interface {
 	Printf(message string, args ...interface{})
-	PromptWithDetails(resourceType, resourceName string) bool
 	Println(message string)
+	Debugln(message string)
+	PromptWithDetails(resourceType, resourceName string) bool
 	NoConfirm()
 }

--- a/cmd/leftovers/main.go
+++ b/cmd/leftovers/main.go
@@ -45,7 +45,7 @@ func main() {
 		return
 	}
 
-	logger := app.NewLogger(os.Stdout, os.Stdin, o.NoConfirm)
+	logger := app.NewLogger(os.Stdout, os.Stdin, o.NoConfirm, o.Debug)
 
 	otherEnvVars := app.NewOtherEnvVars()
 	otherEnvVars.LoadConfig(&o)

--- a/gcp/compute/addresses.go
+++ b/gcp/compute/addresses.go
@@ -30,6 +30,7 @@ func NewAddresses(client addressesClient, logger logger, regions map[string]stri
 func (a Addresses) List(filter string) ([]common.Deletable, error) {
 	addresses := []*gcpcompute.Address{}
 	for _, region := range a.regions {
+		a.logger.Debugf("Listing Addresses for Region %s...\n", region)
 		l, err := a.client.ListAddresses(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Addresses for Region %s: %s", region, err)

--- a/gcp/compute/backend_services.go
+++ b/gcp/compute/backend_services.go
@@ -26,6 +26,7 @@ func NewBackendServices(client backendServicesClient, logger logger) BackendServ
 }
 
 func (b BackendServices) List(filter string) ([]common.Deletable, error) {
+	b.logger.Debugln("Listing Backend Services...")
 	backendServices, err := b.client.ListBackendServices()
 	if err != nil {
 		return nil, fmt.Errorf("List Backend Services: %s", err)

--- a/gcp/compute/disks.go
+++ b/gcp/compute/disks.go
@@ -30,6 +30,7 @@ func NewDisks(client disksClient, logger logger, zones map[string]string) Disks 
 func (d Disks) List(filter string) ([]common.Deletable, error) {
 	disks := []*gcpcompute.Disk{}
 	for _, zone := range d.zones {
+		d.logger.Debugf("Listing Disks for Zone %s...\n", zone)
 		l, err := d.client.ListDisks(zone)
 		if err != nil {
 			return nil, fmt.Errorf("List Disks for zone %s: %s", zone, err)

--- a/gcp/compute/fakes/logger.go
+++ b/gcp/compute/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/compute/firewalls.go
+++ b/gcp/compute/firewalls.go
@@ -26,9 +26,10 @@ func NewFirewalls(client firewallsClient, logger logger) Firewalls {
 }
 
 func (f Firewalls) List(filter string) ([]common.Deletable, error) {
+	f.logger.Debugln("Listing Firewalls...")
 	firewalls, err := f.client.ListFirewalls()
 	if err != nil {
-		return nil, fmt.Errorf("Listing firewalls: %s", err)
+		return nil, fmt.Errorf("Listing Firewalls: %s", err)
 	}
 
 	var resources []common.Deletable

--- a/gcp/compute/firewalls_test.go
+++ b/gcp/compute/firewalls_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Firewalls", func() {
 
 			It("returns the error", func() {
 				_, err := firewalls.List(filter)
-				Expect(err).To(MatchError("Listing firewalls: some error"))
+				Expect(err).To(MatchError("Listing Firewalls: some error"))
 			})
 		})
 

--- a/gcp/compute/forwarding_rules.go
+++ b/gcp/compute/forwarding_rules.go
@@ -30,6 +30,7 @@ func NewForwardingRules(client forwardingRulesClient, logger logger, regions map
 func (f ForwardingRules) List(filter string) ([]common.Deletable, error) {
 	rules := []*gcpcompute.ForwardingRule{}
 	for _, region := range f.regions {
+		f.logger.Debugf("Listing Forwarding Rules for Region %s...\n", region)
 		l, err := f.client.ListForwardingRules(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Forwarding Rules for region %s: %s", region, err)

--- a/gcp/compute/global_addresses.go
+++ b/gcp/compute/global_addresses.go
@@ -26,6 +26,7 @@ func NewGlobalAddresses(client globalAddressesClient, logger logger) GlobalAddre
 }
 
 func (a GlobalAddresses) List(filter string) ([]common.Deletable, error) {
+	a.logger.Debugln("Listing Global Addresses...")
 	addresses, err := a.client.ListGlobalAddresses()
 	if err != nil {
 		return nil, fmt.Errorf("List Global Addresses: %s", err)

--- a/gcp/compute/global_forwarding_rules.go
+++ b/gcp/compute/global_forwarding_rules.go
@@ -26,6 +26,7 @@ func NewGlobalForwardingRules(client globalForwardingRulesClient, logger logger)
 }
 
 func (g GlobalForwardingRules) List(filter string) ([]common.Deletable, error) {
+	g.logger.Debugln("Listing Global Forwarding Rules...")
 	rules, err := g.client.ListGlobalForwardingRules()
 	if err != nil {
 		return nil, fmt.Errorf("List Global Forwarding Rules: %s", err)

--- a/gcp/compute/global_health_checks.go
+++ b/gcp/compute/global_health_checks.go
@@ -26,6 +26,7 @@ func NewGlobalHealthChecks(client globalHealthChecksClient, logger logger) Globa
 }
 
 func (h GlobalHealthChecks) List(filter string) ([]common.Deletable, error) {
+	h.logger.Debugln("Listing Global Health Checks...")
 	checks, err := h.client.ListGlobalHealthChecks()
 	if err != nil {
 		return nil, fmt.Errorf("List Global Health Checks: %s", err)

--- a/gcp/compute/http_health_checks.go
+++ b/gcp/compute/http_health_checks.go
@@ -26,6 +26,7 @@ func NewHttpHealthChecks(client httpHealthChecksClient, logger logger) HttpHealt
 }
 
 func (h HttpHealthChecks) List(filter string) ([]common.Deletable, error) {
+	h.logger.Debugln("Listing Http Health Checks...")
 	checks, err := h.client.ListHttpHealthChecks()
 	if err != nil {
 		return nil, fmt.Errorf("List Http Health Checks: %s", err)

--- a/gcp/compute/https_health_checks.go
+++ b/gcp/compute/https_health_checks.go
@@ -26,6 +26,7 @@ func NewHttpsHealthChecks(client httpsHealthChecksClient, logger logger) HttpsHe
 }
 
 func (h HttpsHealthChecks) List(filter string) ([]common.Deletable, error) {
+	h.logger.Debugln("Listing Https Health Checks...")
 	checks, err := h.client.ListHttpsHealthChecks()
 	if err != nil {
 		return nil, fmt.Errorf("List Https Health Checks: %s", err)

--- a/gcp/compute/images.go
+++ b/gcp/compute/images.go
@@ -26,6 +26,7 @@ func NewImages(client imagesClient, logger logger) Images {
 }
 
 func (i Images) List(filter string) ([]common.Deletable, error) {
+	i.logger.Debugln("Listing Images...")
 	images, err := i.client.ListImages()
 	if err != nil {
 		return nil, fmt.Errorf("List Images: %s", err)

--- a/gcp/compute/instance_group_managers.go
+++ b/gcp/compute/instance_group_managers.go
@@ -30,6 +30,7 @@ func NewInstanceGroupManagers(client instanceGroupManagersClient, logger logger,
 func (i InstanceGroupManagers) List(filter string) ([]common.Deletable, error) {
 	managers := []*gcpcompute.InstanceGroupManager{}
 	for _, zone := range i.zones {
+		i.logger.Debugf("Listing Instance Group Managers for Zone %s...\n", zone)
 		l, err := i.client.ListInstanceGroupManagers(zone)
 		if err != nil {
 			return nil, fmt.Errorf("List Instance Group Managers for zone %s: %s", zone, err)

--- a/gcp/compute/instance_groups.go
+++ b/gcp/compute/instance_groups.go
@@ -30,6 +30,7 @@ func NewInstanceGroups(client instanceGroupsClient, logger logger, zones map[str
 func (i InstanceGroups) List(filter string) ([]common.Deletable, error) {
 	groups := []*gcpcompute.InstanceGroup{}
 	for _, zone := range i.zones {
+		i.logger.Debugf("Listing Instance Groups for Zone %s...\n", zone)
 		l, err := i.client.ListInstanceGroups(zone)
 		if err != nil {
 			return nil, fmt.Errorf("List Instance Groups for zone %s: %s", zone, err)

--- a/gcp/compute/instance_templates.go
+++ b/gcp/compute/instance_templates.go
@@ -26,6 +26,7 @@ func NewInstanceTemplates(client instanceTemplatesClient, logger logger) Instanc
 }
 
 func (i InstanceTemplates) List(filter string) ([]common.Deletable, error) {
+	i.logger.Debugln("Listing Instance Templates...")
 	templates, err := i.client.ListInstanceTemplates()
 	if err != nil {
 		return nil, fmt.Errorf("List Instance Templates: %s", err)

--- a/gcp/compute/instances.go
+++ b/gcp/compute/instances.go
@@ -30,6 +30,7 @@ func NewInstances(client instancesClient, logger logger, zones map[string]string
 func (i Instances) List(filter string) ([]common.Deletable, error) {
 	instances := []*gcpcompute.Instance{}
 	for _, zone := range i.zones {
+		i.logger.Debugf("Listing Instances for Zone %s...\n", zone)
 		l, err := i.client.ListInstances(zone)
 		if err != nil {
 			return nil, fmt.Errorf("List Instances for zone %s: %s", zone, err)

--- a/gcp/compute/logger.go
+++ b/gcp/compute/logger.go
@@ -2,5 +2,7 @@ package compute
 
 type logger interface {
 	Printf(m string, a ...interface{})
+	Debugf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/gcp/compute/networks.go
+++ b/gcp/compute/networks.go
@@ -26,6 +26,7 @@ func NewNetworks(client networksClient, logger logger) Networks {
 }
 
 func (n Networks) List(filter string) ([]common.Deletable, error) {
+	n.logger.Debugln("Listing Networks...")
 	networks, err := n.client.ListNetworks()
 	if err != nil {
 		return nil, fmt.Errorf("List Networks: %s", err)

--- a/gcp/compute/routers.go
+++ b/gcp/compute/routers.go
@@ -30,6 +30,7 @@ func NewRouters(routersClient routersClient, logger logger, regions map[string]s
 func (r Routers) List(filter string) ([]common.Deletable, error) {
 	routers := []*gcpcompute.Router{}
 	for _, region := range r.regions {
+		r.logger.Debugf("Listing Routers for Region %s...\n", region)
 		l, err := r.routersClient.ListRouters(region)
 		if err != nil {
 			return []common.Deletable{}, fmt.Errorf("List Routers for region %s: %s", region, err)

--- a/gcp/compute/routes.go
+++ b/gcp/compute/routes.go
@@ -26,6 +26,7 @@ func NewRoutes(client routesClient, logger logger) Routes {
 }
 
 func (r Routes) List(filter string) ([]common.Deletable, error) {
+	r.logger.Debugln("Listing Routes...")
 	routes, err := r.client.ListRoutes()
 	if err != nil {
 		return nil, fmt.Errorf("List Routes: %s", err)

--- a/gcp/compute/ssl_certificates.go
+++ b/gcp/compute/ssl_certificates.go
@@ -26,6 +26,7 @@ func NewSslCertificates(client sslCertificatesClient, logger logger) SslCertific
 }
 
 func (s SslCertificates) List(filter string) ([]common.Deletable, error) {
+	s.logger.Debugln("Listing SSL Certificates...")
 	sslCertificates, err := s.client.ListSslCertificates()
 	if err != nil {
 		return nil, fmt.Errorf("List Ssl Certificates: %s", err)

--- a/gcp/compute/subnetworks.go
+++ b/gcp/compute/subnetworks.go
@@ -30,6 +30,7 @@ func NewSubnetworks(client subnetworksClient, logger logger, regions map[string]
 func (n Subnetworks) List(filter string) ([]common.Deletable, error) {
 	subnetworks := []*gcpcompute.Subnetwork{}
 	for _, region := range n.regions {
+		n.logger.Debugf("Listing Subnetworks for region %s...\n", region)
 		l, err := n.client.ListSubnetworks(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Subnetworks for region %s: %s", region, err)

--- a/gcp/compute/target_http_proxies.go
+++ b/gcp/compute/target_http_proxies.go
@@ -26,6 +26,7 @@ func NewTargetHttpProxies(client targetHttpProxiesClient, logger logger) TargetH
 }
 
 func (t TargetHttpProxies) List(filter string) ([]common.Deletable, error) {
+	t.logger.Debugln("Listing Target Http Proxies...")
 	targetHttpProxies, err := t.client.ListTargetHttpProxies()
 	if err != nil {
 		return nil, fmt.Errorf("List Target Http Proxies: %s", err)

--- a/gcp/compute/target_https_proxies.go
+++ b/gcp/compute/target_https_proxies.go
@@ -26,6 +26,7 @@ func NewTargetHttpsProxies(client targetHttpsProxiesClient, logger logger) Targe
 }
 
 func (t TargetHttpsProxies) List(filter string) ([]common.Deletable, error) {
+	t.logger.Debugln("Listing Target Https Proxies...")
 	targetHttpsProxies, err := t.client.ListTargetHttpsProxies()
 	if err != nil {
 		return nil, fmt.Errorf("List Target Https Proxies: %s", err)

--- a/gcp/compute/target_pools.go
+++ b/gcp/compute/target_pools.go
@@ -30,6 +30,7 @@ func NewTargetPools(client targetPoolsClient, logger logger, regions map[string]
 func (t TargetPools) List(filter string) ([]common.Deletable, error) {
 	pools := []*gcpcompute.TargetPool{}
 	for _, region := range t.regions {
+		t.logger.Debugf("Listing Target Pools for region %s...\n", region)
 		l, err := t.client.ListTargetPools(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Target Pools for region %s: %s", region, err)

--- a/gcp/compute/target_vpn_gateways.go
+++ b/gcp/compute/target_vpn_gateways.go
@@ -31,6 +31,7 @@ func (t TargetVpnGateways) List(filter string) ([]common.Deletable, error) {
 	gateways := []*gcpcompute.TargetVpnGateway{}
 
 	for _, region := range t.regions {
+		t.logger.Debugf("Listing Target Vpn Gateways for region %s...\n", region)
 		l, err := t.client.ListTargetVpnGateways(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Target Vpn Gateways: %s", err)

--- a/gcp/compute/url_maps.go
+++ b/gcp/compute/url_maps.go
@@ -26,6 +26,7 @@ func NewUrlMaps(client urlMapsClient, logger logger) UrlMaps {
 }
 
 func (u UrlMaps) List(filter string) ([]common.Deletable, error) {
+	u.logger.Debugln("Listing Url Maps...")
 	urlMaps, err := u.client.ListUrlMaps()
 	if err != nil {
 		return nil, fmt.Errorf("List Url Maps: %s", err)

--- a/gcp/compute/vpn_tunnels.go
+++ b/gcp/compute/vpn_tunnels.go
@@ -31,6 +31,7 @@ func (v VpnTunnels) List(filter string) ([]common.Deletable, error) {
 	tunnels := []*gcpcompute.VpnTunnel{}
 
 	for _, region := range v.regions {
+		v.logger.Debugf("Listing Vpn Tunnels for Region %s...\n", region)
 		l, err := v.client.ListVpnTunnels(region)
 		if err != nil {
 			return nil, fmt.Errorf("List Vpn Tunnels: %s", err)

--- a/gcp/container/clusters.go
+++ b/gcp/container/clusters.go
@@ -30,6 +30,7 @@ func NewClusters(client clustersClient, zones map[string]string, logger logger) 
 func (c Clusters) List(filter string) ([]common.Deletable, error) {
 	clusters := []*gcpcontainer.Cluster{}
 	for _, zone := range c.zones {
+		c.logger.Debugf("Listing Clusters for Zone %s...\n", zone)
 		resp, err := c.client.ListClusters(zone)
 		if err != nil {
 			return nil, fmt.Errorf("List Clusters for Zone %s: %s", zone, err)

--- a/gcp/container/fakes/logger.go
+++ b/gcp/container/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/container/logger.go
+++ b/gcp/container/logger.go
@@ -2,5 +2,6 @@ package container
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugf(message string, a ...interface{})
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/gcp/dns/fakes/logger.go
+++ b/gcp/dns/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/dns/logger.go
+++ b/gcp/dns/logger.go
@@ -2,5 +2,6 @@ package dns
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/gcp/dns/managed_zones.go
+++ b/gcp/dns/managed_zones.go
@@ -32,6 +32,7 @@ func NewManagedZones(client managedZonesClient, recordSets recordSets, logger lo
 }
 
 func (m ManagedZones) List(filter string) ([]common.Deletable, error) {
+	m.logger.Debugln("Listing DNS Managed Zones...")
 	managedZones, err := m.client.ListManagedZones()
 	if err != nil {
 		return nil, fmt.Errorf("Listing DNS Managed Zones: %s", err)

--- a/gcp/dns/record_sets.go
+++ b/gcp/dns/record_sets.go
@@ -13,15 +13,18 @@ type recordSetsClient interface {
 
 type RecordSets struct {
 	client recordSetsClient
+	logger logger
 }
 
-func NewRecordSets(client recordSetsClient) RecordSets {
+func NewRecordSets(client recordSetsClient, logger logger) RecordSets {
 	return RecordSets{
 		client: client,
+		logger: logger,
 	}
 }
 
 func (r RecordSets) Delete(managedZone string) error {
+	r.logger.Debugln("Listing DNS Record Sets...")
 	recordSets, err := r.client.ListRecordSets(managedZone)
 	if err != nil {
 		return fmt.Errorf("Listing DNS Record Sets: %s", err)

--- a/gcp/dns/record_sets_test.go
+++ b/gcp/dns/record_sets_test.go
@@ -14,14 +14,16 @@ import (
 var _ = Describe("RecordSets", func() {
 	var (
 		client *fakes.RecordSetsClient
+		logger *fakes.Logger
 
 		recordSets dns.RecordSets
 	)
 
 	BeforeEach(func() {
 		client = &fakes.RecordSetsClient{}
+		logger = &fakes.Logger{}
 
-		recordSets = dns.NewRecordSets(client)
+		recordSets = dns.NewRecordSets(client, logger)
 	})
 
 	Describe("Delete", func() {

--- a/gcp/iam/fakes/logger.go
+++ b/gcp/iam/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/iam/logger.go
+++ b/gcp/iam/logger.go
@@ -2,5 +2,6 @@ package iam
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/gcp/iam/service_accounts.go
+++ b/gcp/iam/service_accounts.go
@@ -34,6 +34,7 @@ func NewServiceAccounts(client serviceAccountsClient, projectName string, projec
 }
 
 func (s ServiceAccounts) List(filter string) ([]common.Deletable, error) {
+	s.logger.Debugln("Listing IAM Service Accounts...")
 	accounts, err := s.client.ListServiceAccounts()
 	if err != nil {
 		return nil, fmt.Errorf("List IAM Service Accounts: %s", err)

--- a/gcp/leftovers.go
+++ b/gcp/leftovers.go
@@ -163,7 +163,7 @@ func NewLeftovers(logger logger, keyPath string) (Leftovers, error) {
 			compute.NewAddresses(client, logger, regions),
 			compute.NewSslCertificates(client, logger),
 			iam.NewServiceAccounts(iamClient, p.ProjectId, projectNumber, logger),
-			dns.NewManagedZones(dnsClient, dns.NewRecordSets(dnsClient), logger),
+			dns.NewManagedZones(dnsClient, dns.NewRecordSets(dnsClient, logger), logger),
 			sql.NewInstances(sqlClient, logger),
 			storage.NewBuckets(storageClient, logger),
 			container.NewClusters(containerClient, zones, logger),

--- a/gcp/logger.go
+++ b/gcp/logger.go
@@ -3,6 +3,8 @@ package gcp
 type logger interface {
 	Printf(message string, a ...interface{})
 	Println(message string)
+	Debugf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 	NoConfirm()
 }

--- a/gcp/sql/fakes/logger.go
+++ b/gcp/sql/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/sql/instances.go
+++ b/gcp/sql/instances.go
@@ -26,6 +26,7 @@ func NewInstances(client instancesClient, logger logger) Instances {
 }
 
 func (i Instances) List(filter string) ([]common.Deletable, error) {
+	i.logger.Debugln("Listing SQL Instances...")
 	instances, err := i.client.ListInstances()
 	if err != nil {
 		return nil, fmt.Errorf("List SQL Instances: %s", err)

--- a/gcp/sql/logger.go
+++ b/gcp/sql/logger.go
@@ -2,5 +2,6 @@ package sql
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/gcp/storage/buckets.go
+++ b/gcp/storage/buckets.go
@@ -29,6 +29,7 @@ func NewBuckets(client bucketsClient, logger logger) Buckets {
 }
 
 func (i Buckets) List(filter string) ([]common.Deletable, error) {
+	i.logger.Debugln("Listing Storage Buckets...")
 	buckets, err := i.client.ListBuckets()
 	if err != nil {
 		return nil, fmt.Errorf("List Storage Buckets: %s", err)

--- a/gcp/storage/fakes/logger.go
+++ b/gcp/storage/fakes/logger.go
@@ -11,6 +11,21 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebugfCall struct {
+		Receives struct {
+			Message   string
+			Arguments []interface{}
+		}
+		Messages []string
+	}
+
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +43,19 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugf(message string, a ...interface{}) {
+	l.DebugfCall.Receives.Message = message
+	l.DebugfCall.Receives.Arguments = a
+
+	l.DebugfCall.Messages = append(l.DebugfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/gcp/storage/logger.go
+++ b/gcp/storage/logger.go
@@ -2,5 +2,6 @@ package storage
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/nsxt/groupingobjects/fakes/logger.go
+++ b/nsxt/groupingobjects/fakes/logger.go
@@ -11,6 +11,13 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +35,12 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/nsxt/groupingobjects/ip_sets.go
+++ b/nsxt/groupingobjects/ip_sets.go
@@ -23,6 +23,7 @@ func NewIPSets(client groupingObjectsAPI, ctx context.Context, logger logger) IP
 }
 
 func (i IPSets) List(filter string) ([]common.Deletable, error) {
+	i.logger.Debugln("Listing IP Sets...")
 	result, _, err := i.client.ListIPSets(i.ctx, map[string]interface{}{})
 
 	if err != nil {

--- a/nsxt/groupingobjects/logger.go
+++ b/nsxt/groupingobjects/logger.go
@@ -2,5 +2,6 @@ package groupingobjects
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/nsxt/groupingobjects/ns_groups.go
+++ b/nsxt/groupingobjects/ns_groups.go
@@ -23,6 +23,7 @@ func NewNSGroups(client groupingObjectsAPI, ctx context.Context, logger logger) 
 }
 
 func (n NSGroups) List(filter string) ([]common.Deletable, error) {
+	n.logger.Debugln("Listing NS Groups...")
 	result, _, err := n.client.ListNSGroups(n.ctx, map[string]interface{}{})
 
 	if err != nil {

--- a/nsxt/groupingobjects/ns_services.go
+++ b/nsxt/groupingobjects/ns_services.go
@@ -23,6 +23,7 @@ func NewNSServices(client groupingObjectsAPI, ctx context.Context, logger logger
 }
 
 func (n NSServices) List(filter string) ([]common.Deletable, error) {
+	n.logger.Debugln("Listing NS Services...")
 	result, _, err := n.client.ListNSServices(n.ctx, map[string]interface{}{})
 
 	if err != nil {

--- a/nsxt/leftovers.go
+++ b/nsxt/leftovers.go
@@ -15,6 +15,7 @@ import (
 type logger interface {
 	Printf(message string, a ...interface{})
 	Println(message string)
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 	NoConfirm()
 }

--- a/nsxt/logicalrouting/fakes/logger.go
+++ b/nsxt/logicalrouting/fakes/logger.go
@@ -11,6 +11,13 @@ type Logger struct {
 		Messages []string
 	}
 
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -28,6 +35,12 @@ func (l *Logger) Printf(message string, a ...interface{}) {
 	l.PrintfCall.Receives.Arguments = a
 
 	l.PrintfCall.Messages = append(l.PrintfCall.Messages, fmt.Sprintf(message, a...))
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/nsxt/logicalrouting/logger.go
+++ b/nsxt/logicalrouting/logger.go
@@ -2,5 +2,6 @@ package logicalrouting
 
 type logger interface {
 	Printf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }

--- a/nsxt/logicalrouting/tier1_routers.go
+++ b/nsxt/logicalrouting/tier1_routers.go
@@ -23,6 +23,7 @@ func NewTier1Routers(client logicalRoutingAPI, ctx context.Context, logger logge
 }
 
 func (t Tier1Routers) List(filter string) ([]common.Deletable, error) {
+	t.logger.Debugln("Listing Tier 1 Routers...")
 	result, _, err := t.client.ListLogicalRouters(t.ctx, map[string]interface{}{
 		"routerType": "TIER1",
 	})

--- a/openstack/compute_instances.go
+++ b/openstack/compute_instances.go
@@ -25,6 +25,7 @@ func NewComputeInstances(computeClient ComputeClient, logger logger) ComputeInst
 }
 
 func (ci ComputeInstances) List() ([]common.Deletable, error) {
+	ci.logger.Debugln("Listing Compute Instances...")
 	computeInstances, err := ci.computeClient.List()
 	if err != nil {
 		return nil, fmt.Errorf("List Compute Instances: %s", err)

--- a/openstack/fakes/logger.go
+++ b/openstack/fakes/logger.go
@@ -1,6 +1,15 @@
 package fakes
 
+import "fmt"
+
 type Logger struct {
+	DebuglnCall struct {
+		Receives struct {
+			Message string
+		}
+		Messages []string
+	}
+
 	PromptWithDetailsCall struct {
 		CallCount int
 		Receives  struct {
@@ -14,6 +23,12 @@ type Logger struct {
 
 type LoggerPromptWithDetailsCallReturn struct {
 	Bool bool
+}
+
+func (l *Logger) Debugln(message string) {
+	l.DebuglnCall.Receives.Message = message
+
+	l.DebuglnCall.Messages = append(l.DebuglnCall.Messages, fmt.Sprintln(message))
 }
 
 func (l *Logger) PromptWithDetails(resourceType, resourceName string) bool {

--- a/openstack/images.go
+++ b/openstack/images.go
@@ -25,6 +25,7 @@ func NewImages(client imageServiceClient, logger logger) Images {
 }
 
 func (i Images) List() ([]common.Deletable, error) {
+	i.logger.Debugln("Listing Images...")
 	images, err := i.client.List()
 	if err != nil {
 		return nil, fmt.Errorf("List Images: %s", err)

--- a/openstack/leftovers.go
+++ b/openstack/leftovers.go
@@ -20,6 +20,7 @@ type listTyper interface {
 type logger interface {
 	Printf(message string, a ...interface{})
 	Println(message string)
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 	NoConfirm()
 }

--- a/openstack/volumes.go
+++ b/openstack/volumes.go
@@ -25,6 +25,7 @@ func NewVolumes(client volumesClient, logger logger) Volumes {
 }
 
 func (v Volumes) List() ([]common.Deletable, error) {
+	v.logger.Debugln("Listing Volumes...")
 	result, err := v.client.List()
 	if err != nil {
 		return nil, fmt.Errorf("List Volumes: %s", err)

--- a/vsphere/logger.go
+++ b/vsphere/logger.go
@@ -3,5 +3,7 @@ package vsphere
 type logger interface {
 	Printf(message string, a ...interface{})
 	Println(message string)
+	Debugf(message string, a ...interface{})
+	Debugln(message string)
 	PromptWithDetails(resourceType, resourceName string) bool
 }


### PR DESCRIPTION
This change adds a new flag, `--debug`, which when enabled will print something like `Listing Tier 1 Routers...` for each resource type in the targeted IaaS.

Future work that could build on this:
- include timestamps so that we can see how long each list call takes (and maybe make some performance optimizations)
- AWS support (I didn't do this for AWS yet because there are a ton of resources, and I didn't want to waste time changing them all manually if there's a good way to automate making this change)