### PR TITLE
Add support for AWS assumed roles

### DIFF
--- a/app/env_vars.go
+++ b/app/env_vars.go
@@ -14,6 +14,7 @@ type Options struct {
 
 	AWSAccessKeyID       string `long:"aws-access-key-id"        env:"BBL_AWS_ACCESS_KEY_ID"        description:"AWS access key id."`
 	AWSSecretAccessKey   string `long:"aws-secret-access-key"    env:"BBL_AWS_SECRET_ACCESS_KEY"    description:"AWS secret access key."`
+	AWSAssumeRole        string `long:"aws-assume-role"          env:"BBL_AWS_ASSUME_ROLE"          description:"AWS assume role ARN."`
 	AWSSessionToken      string `long:"aws-session-token"        env:"BBL_AWS_SESSION_TOKEN"        description:"AWS session token."`
 	AWSRegion            string `long:"aws-region"               env:"BBL_AWS_REGION"               description:"AWS region."`
 	AzureClientID        string `long:"azure-client-id"          env:"BBL_AZURE_CLIENT_ID"          description:"Azure client id."`
@@ -60,6 +61,9 @@ func (e OtherEnvVars) LoadConfig(o *Options) {
 		}
 		if o.AWSSecretAccessKey == "" {
 			o.AWSSecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		}
+		if o.AWSAssumeRole == "" {
+			o.AWSAssumeRole = os.Getenv(("AWS_ROLE_ARN"))
 		}
 		if o.AWSSessionToken == "" {
 			o.AWSSessionToken = os.Getenv("AWS_SESSION_TOKEN")

--- a/app/env_vars_test.go
+++ b/app/env_vars_test.go
@@ -26,6 +26,7 @@ var _ = Describe("OtherEnvVars", func() {
 				os.Setenv("AWS_SECRET_ACCESS_KEY", "kiwi")
 				os.Setenv("AWS_SESSION_TOKEN", "pineapple")
 				os.Setenv("AWS_DEFAULT_REGION", "plum")
+				os.Setenv("AWS_ROLE_ARN", "pomegranate")
 			})
 
 			AfterEach(func() {
@@ -42,6 +43,7 @@ var _ = Describe("OtherEnvVars", func() {
 				Expect(options.AWSSecretAccessKey).To(Equal("kiwi"))
 				Expect(options.AWSSessionToken).To(Equal("pineapple"))
 				Expect(options.AWSRegion).To(Equal("plum"))
+				Expect(options.AWSAssumeRole).To(Equal(("pomegranate")))
 			})
 		})
 

--- a/cmd/leftovers/leftovers.go
+++ b/cmd/leftovers/leftovers.go
@@ -28,7 +28,7 @@ func GetLeftovers(logger *app.Logger, o app.Options) (leftovers, error) {
 
 	switch o.IAAS {
 	case app.AWS:
-		l, err = aws.NewLeftovers(logger, o.AWSAccessKeyID, o.AWSSecretAccessKey, o.AWSSessionToken, o.AWSRegion)
+		l, err = aws.NewLeftoversWithAssumeRole(logger, o.AWSAccessKeyID, o.AWSSecretAccessKey, o.AWSAssumeRole, o.AWSSessionToken, o.AWSRegion)
 	case app.Azure:
 		l, err = azure.NewLeftovers(logger, o.AzureClientID, o.AzureClientSecret, o.AzureSubscriptionID, o.AzureTenantID)
 	case app.GCP:


### PR DESCRIPTION
AWS supports the concept of "assume role" where one account can be granted temporary credentials to another approved account. This commit adds support for assume role in `leftovers` in preparation for adding support in `bbl`.

More information about assume role:
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html